### PR TITLE
Add exits and exits0

### DIFF
--- a/bash-tap
+++ b/bash-tap
@@ -158,6 +158,28 @@ function ok() {
     _bt_print_out
 }
 
+function exits() {
+    local name="$1"
+    local expected="$2"
+    shift 2
+
+    "$@"
+    retcode=$?
+
+    if [ $retcode -eq $expected ]; then
+        ok 1 "$name"
+    else
+        ok 0 "$name"
+        _is_diag "$retcode" "$expected"
+    fi
+}
+
+function exits0() {
+    local name="$1"
+    shift
+    exits "$name" 0 "$@"
+}
+
 function _is_diag() {
     local result="$1"
     local expected="$2"


### PR DESCRIPTION
After getting over my initial shock that bash-tap provided no such assertion function already, I wrote this.

My guess is that prior use cases have focused on testing code actually _within_ bash rather than programs called _from_ it.
